### PR TITLE
Fix startup errors and motor sync

### DIFF
--- a/models/mapper.py
+++ b/models/mapper.py
@@ -31,6 +31,18 @@ class Mapper:
         self.nm_arr: np.ndarray
         self._load_csv()
 
+    # ------------------------------ file I/O -------------------------------
+    def load(self, path: pathlib.Path) -> None:
+        """Load calibration data from the given CSV file."""
+        self.csv_path = pathlib.Path(path)
+        self._load_csv()
+
+    def save(self, path: pathlib.Path | None = None) -> None:
+        """Save current calibration data to CSV."""
+        if path is not None:
+            self.csv_path = pathlib.Path(path)
+        self._save_csv()
+
     # -------------------------------- API ---------------------------------
     def nm_from_idx(self, idx: float) -> float:
         """輸入 idx (float 可)，回傳波長 nm；範圍外 raise ValueError"""

--- a/widgets/calibration_widget.py
+++ b/widgets/calibration_widget.py
@@ -10,6 +10,7 @@ class CalibrationWidget(QtWidgets.QWidget):
         self.motor = motor
         self.mapper = mapper
         self.cal_tbl = []                         # 暫存校正點
+        self._idx_known = False
 
         # ───── 控件 ─────
         self.spn_nm   = QtWidgets.QDoubleSpinBox(); self.spn_nm.setRange(100,3000); self.spn_nm.setDecimals(1); self.spn_nm.setSingleStep(0.1)
@@ -39,10 +40,20 @@ class CalibrationWidget(QtWidgets.QWidget):
         self.btn_add.clicked.connect(self.add_point)
         self.btn_save.clicked.connect(self.on_save_calib)
         self.btn_load.clicked.connect(self.on_load_calib)
-        self.motor.positionChanged.connect(self.spn_idx_now.setValue)
-        self.spn_idx_now.editingFinished.connect(
-            lambda: setattr(self.motor, "position", self.spn_idx_now.value())
-        )
+        self.motor.positionChanged.connect(self._on_motor_pos)
+        self.motor.hitLimit.connect(self._on_limit)
+        self.spn_idx_now.editingFinished.connect(self._on_idx_edit)
+
+    def _on_motor_pos(self, val: int) -> None:
+        self._idx_known = True
+        self.spn_idx_now.setValue(val)
+
+    def _on_idx_edit(self) -> None:
+        self._idx_known = True
+        self.motor.position = self.spn_idx_now.value()
+
+    def _on_limit(self, idx: int) -> None:
+        QtWidgets.QMessageBox.warning(self, "觸及極限", f"位置 {idx} 超出安全範圍")
 
 
     # ───── 功能 ─────
@@ -55,6 +66,10 @@ class CalibrationWidget(QtWidgets.QWidget):
     
     def jog(self, sign: int):
         if hasattr(self, "worker") and self.worker.isRunning():
+            return
+
+        if not self._idx_known:
+            QtWidgets.QMessageBox.warning(self, "未知計數器", "請先輸入目前計數器位置！")
             return
 
         step_nm = self.spn_step.value()
@@ -72,26 +87,28 @@ class CalibrationWidget(QtWidgets.QWidget):
 
         target_idx = max(0, min(999, self.motor.position + sign * pulse_step))
         self.worker = MotorMoveWorker(self.motor, target_idx, self)
-        self.worker.finished.connect(self.spn_idx_now.setValue)
+        self.worker.finished.connect(self._on_motor_pos)
         self.worker.start()
  
     def add_point(self):
         lam_nm = self.spn_nm.value()
         pulse  = self.spn_idx_now.value()
 
+        if not self._idx_known:
+            QtWidgets.QMessageBox.warning(self, "未知計數器", "請先輸入目前計數器位置！")
+            return
+
         # ① 寫入 Mapper（真正的校正表）
-        self.mapper.add_point(idx=pulse, nm=lam_nm)     # ★ 改這行
+        self.mapper.add_point(idx=pulse, nm=lam_nm)
 
         # ② 本地暫存，用來估斜率
-        self.mapper.add_point(idx=pulse, nm=lam_nm)
+        self.cal_tbl.append((lam_nm, pulse))
+
         # 將 Mapper 的新資料丟出去，讓 ExperimentWidget 重建校正表
         self.cal_loaded.emit(list(zip(self.mapper.nm_arr, self.mapper.idx_arr)))
 
         # ③ 更新 GUI
         self.lst_pts.addItem(f"λ = {lam_nm:.1f} nm   →   p = {pulse}")
-
-        # ④ 通知 ExperimentWidget 重新建立校正表
-        self.cal_loaded.emit(self.cal_tbl)
 
     
     def on_save_calib(self):


### PR DESCRIPTION
## Summary
- ensure motor position updates emit signals and add close method
- reset serial buffer before sending commands
- show fatal dialog when hardware missing
- sync motor index inputs across tabs and warn on unsafe moves
- block operations until initial index is entered

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_685ea844eb808330adf750d82d851d8e