### PR TITLE
Improve motor handling checks

### DIFF
--- a/drivers/motor.py
+++ b/drivers/motor.py
@@ -34,9 +34,9 @@ class MotorArduino(QObject):
     positionChanged = pyqtSignal(int)
 
     BAUDRATE       = 115200
-    TIMEOUT_BUFFER = 0.5         # s，加在估算時間後
+    TIMEOUT_BUFFER = 1.0         # s，加在估算時間後 (提高容錯)
     PULSE_PER_IDX  = 10          # 1 idx = 10 pulse
-    PULSE_TIME     = 0.002       # s，每脈衝驅動時間
+    PULSE_TIME     = 0.003       # s，每脈衝驅動時間 (放慢估計避免 no ACK)
 
     _lock = threading.Lock()
 

--- a/models/mapper.py
+++ b/models/mapper.py
@@ -29,6 +29,7 @@ class Mapper:
         self.csv_path = csv_path
         self.idx_arr: np.ndarray
         self.nm_arr: np.ndarray
+        self.loaded = False
         self._load_csv()
 
     # ------------------------------ file I/O -------------------------------
@@ -79,6 +80,7 @@ class Mapper:
             # 空表 ── 先放 0 點
             self.idx_arr = np.array([], dtype=float)
             self.nm_arr = np.array([], dtype=float)
+            self.loaded = False
             return
         idx_list: List[float] = []
         nm_list: List[float] = []
@@ -92,6 +94,7 @@ class Mapper:
                     continue
         self.idx_arr = np.array(idx_list, dtype=float)
         self.nm_arr = np.array(nm_list, dtype=float)
+        self.loaded = self.point_count() >= MIN_POINTS
 
     def _save_csv(self) -> None:
         with self.csv_path.open("w", newline="") as f:


### PR DESCRIPTION
## Summary
- increase motor timeout constants to reduce no-ack issues
- add Mapper.loaded flag and use to validate calibration status
- restrict experiment page motor actions until counter and calibration are both provided

## Testing
- `python -m py_compile drivers/motor.py models/mapper.py widgets/*.py views/*.py workers.py`

------
https://chatgpt.com/codex/tasks/task_e_686cbe834b908330ad62ffa76dd39ac7